### PR TITLE
Fix a typo in section 在客户端调用以 TensorFlow Serving 部署的模型 of chapter Ten…

### DIFF
--- a/source/_static/code/zh/savedmodel/keras/client.py
+++ b/source/_static/code/zh/savedmodel/keras/client.py
@@ -6,7 +6,7 @@ from zh.model.utils import MNISTLoader
 
 data_loader = MNISTLoader()
 data = json.dumps({
-    "instances": data_loader.test_data[0:3].tolist()
+    "instances": data_loader.test_data[0:10].tolist()
     })
 headers = {"content-type": "application/json"}
 json_response = requests.post(


### PR DESCRIPTION
在 “在客户端调用以 TensorFlow Serving 部署的模型” 这一小节中， Python客户端示例中的代码有误
```
data = json.dumps({
    "instances": data_loader.test_data[0:3].tolist()
    })
```
应将[0:3]改为[0:10]才能得到输出为10个元素
```
[7 2 1 0 4 1 4 9 6 9]
[7 2 1 0 4 1 4 9 5 9]
```